### PR TITLE
Make the ScreenShotPlugin class `sys` only + sort imports

### DIFF
--- a/src/flixel/addons/plugin/ScreenShotPlugin.hx
+++ b/src/flixel/addons/plugin/ScreenShotPlugin.hx
@@ -1,15 +1,19 @@
 package flixel.addons.plugin;
 
-import flixel.util.FlxSignal.FlxTypedSignal;
-import flixel.FlxCamera;
-import flixel.system.FlxAssets.FlxSoundAsset;
-import openfl.utils.ByteArray;
-import openfl.display.Sprite;
-import flixel.tweens.FlxTween;
+#if sys
 import flixel.FlxG;
+import flixel.FlxCamera;
+import flixel.tweens.FlxTween;
+
+import flixel.input.keyboard.FlxKey;
+import flixel.util.FlxSignal.FlxTypedSignal;
+import flixel.system.FlxAssets.FlxSoundAsset;
+
+import openfl.display.Sprite;
+import openfl.utils.ByteArray;
+
 import openfl.display.Bitmap;
 import openfl.display.BitmapData;
-import flixel.input.keyboard.FlxKey;
 
 using StringTools;
 
@@ -318,3 +322,4 @@ enum abstract FileFormatOption(String) from String {
         }
     }
 }
+#end

--- a/src/screenshotplugin/ScreenShotPlugin.hx
+++ b/src/screenshotplugin/ScreenShotPlugin.hx
@@ -1,4 +1,6 @@
 package screenshotplugin;
 
+#if sys
 @:deprecated("screenshotplugin.ScreenShotPlugin is deprecated, use flixel.addons.plugin.ScreenShotPlugin instead")
 typedef ScreenShotPlugin = flixel.addons.plugin.ScreenShotPlugin;
+#end


### PR DESCRIPTION
Non-sys targets does not have access to `FileSystem` and `File` which makes the plugin useless in those targets
Also makes the imports looks better